### PR TITLE
Fix DevPod Icon not displaying in dock

### DIFF
--- a/devpod/devpod.spec
+++ b/devpod/devpod.spec
@@ -4,7 +4,7 @@
 Name:           devpod
 # renovate: datasource=github-releases depName=loft-sh/devpod
 Version:        v0.6.15
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Codespaces but open-source, client-only and unopinionated.
 
 License:        MPL-2.0
@@ -22,6 +22,12 @@ Codespaces but open-source, client-only and unopinionated: Works with any IDE an
 %autosetup -c
 
 %install
+
+# DevPod does not ship with a `StartupWMClass` key in the desktop file, which causes
+# missing icons in GNOME's Dock and KDE's taskbar. Until fixed, we solve this issue here.
+# https://github.com/loft-sh/devpod/issues/1776
+echo "StartupWMClass=dev-pod-desktop" >> usr/share/applications/DevPod.desktop
+
 install -Dm0755 -t %{buildroot}%{_bindir} usr/bin/dev-pod-desktop
 install -Dm0755 -t %{buildroot}%{_bindir} usr/bin/devpod-cli
 install -Dm0644 -t %{buildroot}%{_datadir}/applications usr/share/applications/DevPod.desktop

--- a/devpod/devpod.spec
+++ b/devpod/devpod.spec
@@ -22,12 +22,10 @@ Codespaces but open-source, client-only and unopinionated: Works with any IDE an
 %autosetup -c
 
 %install
-
 # DevPod does not ship with a `StartupWMClass` key in the desktop file, which causes
 # missing icons in GNOME's Dock and KDE's taskbar. Until fixed, we solve this issue here.
 # https://github.com/loft-sh/devpod/issues/1776
-echo "StartupWMClass=dev-pod-desktop" >> usr/share/applications/DevPod.desktop
-
+echo "StartupWMClass=dev-pod-desktop" | tee -a usr/share/applications/DevPod.desktop
 install -Dm0755 -t %{buildroot}%{_bindir} usr/bin/dev-pod-desktop
 install -Dm0755 -t %{buildroot}%{_bindir} usr/bin/devpod-cli
 install -Dm0644 -t %{buildroot}%{_datadir}/applications usr/share/applications/DevPod.desktop


### PR DESCRIPTION
As of this moment, DevPod does not set the `StartupWMClass` key in the desktop file. This causes some issues with GNOME and KDE when displaying the icon in the Dock/Taskbar, and 
may cause the program to become non-responsive when trying to use the minimize/maximize/close buttons.

This issue has been reported upstream, and this fix will be reverted if it is eventually fixed.

Bumping the release version to prevent problems in COPR
