### PR TITLE
fix act go

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,7 @@ build $SPEC_FILE $MOCK_ARGS:
     OUTDIR="${OUTDIR:-/tmp/rpmbuild}"
     SPEC_PATH=$(realpath $SPEC_FILE)
     SPEC_NAME=$(basename $SPEC_PATH)
+    SPEC_DIR=$(dirname $SPEC_PATH)
 
     if [ -d ${OUTDIR} ]; then
         rm -fr ${OUTDIR}
@@ -15,6 +16,7 @@ build $SPEC_FILE $MOCK_ARGS:
     mkdir ${OUTDIR}
 
     rpkg spec --spec ${SPEC_PATH} --outdir ${OUTDIR}
+    cp ${SPEC_DIR}/*.patch ${OUTDIR}
     rpmlint ${OUTDIR}/${SPEC_NAME}
     spectool -ga ${OUTDIR}/${SPEC_NAME} --directory ${OUTDIR}
     rpkg --path ${OUTDIR} srpm --outdir ${OUTDIR}

--- a/act-cli/0001-Downgrade-go-to-1.23.patch
+++ b/act-cli/0001-Downgrade-go-to-1.23.patch
@@ -1,0 +1,24 @@
+From 5ef67d7654f2fb8c1f8db65ec82a85129128c30b Mon Sep 17 00:00:00 2001
+From: Nathanael Rolim <natanael.rolim@hotmail.com>
+Date: Tue, 1 Apr 2025 16:32:36 -0300
+Subject: [PATCH] Downgrade go to 1.23
+
+---
+ go.mod | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/go.mod b/go.mod
+index 5afb235..cba2bdb 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/nektos/act
+ 
+-go 1.24
++go 1.23
+ 
+ require (
+ 	github.com/AlecAivazis/survey/v2 v2.3.7
+-- 
+2.49.0
+

--- a/act-cli/act-cli.spec
+++ b/act-cli/act-cli.spec
@@ -4,12 +4,13 @@
 Name:           act-cli
 # renovate: datasource=github-releases depName=nektos/act
 Version:        v0.2.76
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        Run your GitHub Actions locally
 License:        MIT
 
 URL:            https://github.com/nektos/act
 Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Patch:          0001-Downgrade-go-to-1.23.patch
 
 BuildRequires:  git
 BuildRequires:  golang
@@ -17,19 +18,19 @@ BuildRequires:  make
 
 Requires:       (podman or moby or docker or docker-ce or docker-ce-cli or docker-ee)
 
+%global trimmed_version %(echo %{version} | tr -d "v")
+
 %description
 Run your GitHub Actions locally
 
 %prep
-%autosetup -c
+%autosetup -n act-%{trimmed_version}
 
 %build
-ver=$(echo %{version} | tr -d "v")
-mv act-${ver}/* .
+go mod tidy
 go build \
     -trimpath \
     -buildmode=pie \
-    -mod=readonly \
     -modcacherw \
     -ldflags "-linkmode=external -X main.version=%{version}"
 


### PR DESCRIPTION
Upstream changed the minimum go version to 1.24, however Fedora and its downstream
variants freeze the version of go available in distributions. Everything up to
Fedora 42 (incl. EL10) is frozen on go 1.23.x, causing all builds to fail.
This patch changes the minimum go version in `go.mod` to 1.23 again. Until this moment,
no problem is caused by this change.